### PR TITLE
fix: avoid locals-based g_seq check for torch.compile

### DIFF
--- a/kairos/third_party/fla/layers/gated_deltanet_with_tp.py
+++ b/kairos/third_party/fla/layers/gated_deltanet_with_tp.py
@@ -640,11 +640,11 @@ class GatedDeltaNet(nn.Module):
             if world_size > 1:
                 # determine gating sequence layout (g_seq). If g_seq was
                 # produced earlier, reuse it; otherwise build from g_full.
-                if 'g_seq' in locals():
-                    g_seq_final = g_seq
-                else:
+                if g_seq is None:
                     g_full_4 = rearrange(g_full, 'b t (h d) -> b t h d', d=self.head_v_dim)
                     g_seq_final = _all2all_head_to_seq(g_full_4, self.tp_group, self.tp_chunk_list)
+                else:
+                    g_seq_final = g_seq
                 # choose input for norm: prefer o_seq (head->seq result) when available
                 o_in = o_seq if 'o_seq' in locals() else o
                 o_seq_norm = self.o_norm(o_in, g_seq_final, tp_group=self.tp_group)


### PR DESCRIPTION
**问题：**
原逻辑通过 if 'g_seq' in locals() 判断 g_seq 是否存在，这种写法依赖运行时的局部变量状态，同时这类动态判断方式对torch.compile 不够友好，可能影响图捕获和编译稳定性。
**修改点：**
将原来的 locals() 判断改为显式的 None 判断：
当 g_seq 已经提前计算好时，直接复用；
当 g_seq 为空时，再通过 g_full 重建 g_seq_final。
这样修改后，分支逻辑更清晰，减少了对动态局部变量检查的依赖，并增强了与 torch.compile 的兼容性和执行稳定性。