### PR TITLE
feat: add sequence-parallel t_mod and chunked FFN optimization

### DIFF
--- a/kairos/configs/kairos_4b_config_DMD.py
+++ b/kairos/configs/kairos_4b_config_DMD.py
@@ -20,6 +20,7 @@ pipeline = dict(
         load_dit_fn='strict_load',
         vram_management_enabled=False,
         selected_sampling_time = [1000, 800, 500, 100],
+        use_unified_sequence_parallel=True,
         dit_config = {
             "dit_type" : 'KairosDiT',
             "has_image_input": False,

--- a/kairos/modules/dits/kairos_dit.py
+++ b/kairos/modules/dits/kairos_dit.py
@@ -470,7 +470,6 @@ class SelfAttentionTP(nn.Module):
 
         self.tp_group = parallel_state.get_context_parallel_group()
         self.tp_size = parallel_state.get_context_parallel_world_size()
-        self.context_group = self.tp_group
 
         if self.num_heads % self.tp_size != 0:
             self.tp_chunk_list = build_tp_chunk_list(self.num_heads, self.tp_size)
@@ -513,7 +512,6 @@ class SelfAttentionTP(nn.Module):
         k = self.norm_k(self.k(x))
         v = self.v(x)
 
-        freqs = _distribute_freqs_sp(freqs, self.context_group)
         if FLAGS_KAIROS_IS_METAX:
             q = rope_apply_for3d_triton(q, f, freqs, self.num_heads)
             k = rope_apply_for3d_triton(k, f, freqs, self.num_heads)
@@ -521,9 +519,9 @@ class SelfAttentionTP(nn.Module):
             q = rope_apply_for3d(q, f, freqs, self.num_heads)
             k = rope_apply_for3d(k, f, freqs, self.num_heads)
 
-        q = all2all_seq_to_head(q, self.context_group, self.tp_chunk_list, self.head_dim)
-        k = all2all_seq_to_head(k, self.context_group, self.tp_chunk_list, self.head_dim)
-        v = all2all_seq_to_head(v, self.context_group, self.tp_chunk_list, self.head_dim)
+        q = all2all_seq_to_head(q, self.tp_group, self.tp_chunk_list, self.head_dim)
+        k = all2all_seq_to_head(k, self.tp_group, self.tp_chunk_list, self.head_dim)
+        v = all2all_seq_to_head(v, self.tp_group, self.tp_chunk_list, self.head_dim)
 
         seq_local = x.shape[1]
         seq_global = seq_local * self.tp_size
@@ -550,7 +548,7 @@ class SelfAttentionTP(nn.Module):
             x = rearrange(x, "(b d) (n l) c -> b (n d l) c", l=L, d=dilated_length)
             if pad_len != 0:
                 x = x[:, :-pad_len]
-        x = all2all_head_to_seq(x, self.context_group, self.tp_chunk_list, self.head_dim)
+        x = all2all_head_to_seq(x, self.tp_group, self.tp_chunk_list, self.head_dim)
 
         out = self.o(x)
 
@@ -731,29 +729,16 @@ class DiTBlock(nn.Module):
                     t_c = t_c[:, start_idx:end_idx, :]
 
             return t_c + m_c
-        
-        use_seq_parallel = self.use_seq_parallel
-        if self.is_first_block and use_seq_parallel:
-            distributed_x = _distribute_input_sp(x, self.context_group)
-        else:
-            distributed_x = x
 
-        sp_slice_args = None
-        if use_seq_parallel:
-            start_idx = self.context_group_rank * distributed_x.shape[1]
-            end_idx = (self.context_group_rank + 1) * distributed_x.shape[1]
-            sp_slice_args = (start_idx, end_idx)
-
-        scale_msa = get_mod_chunk(0, sp_slice=has_seq and sp_slice_args or None)
-        shift_msa = get_mod_chunk(1, sp_slice=has_seq and sp_slice_args or None)
-
+        scale_msa = get_mod_chunk(0)
+        shift_msa = get_mod_chunk(1)
+        gate_msa = get_mod_chunk(2)
         # self-attention
-        input_x_local = modulate(self.self_attn_norm(distributed_x), shift_msa, scale_msa)
+        input_x_local = modulate(self.self_attn_norm(x), shift_msa, scale_msa)
         del scale_msa, shift_msa
         if self.use_linear_attn:
             chunk_size = 40768 // 7
             input_x = _gather_input_sp(input_x_local, self.context_group)
-            full_x = _gather_input_sp(distributed_x, self.context_group)
             if input_x.shape[1] > chunk_size:
                 cache = fla_Cahce.from_legacy_cache()
                 outputs = []
@@ -771,34 +756,50 @@ class DiTBlock(nn.Module):
                 attn_out = torch.cat(outputs, dim=1)
             else:
                 attn_out, _, _ = self.gated_delta(input_x)
-            gate_msa = get_mod_chunk(2)
-            full_x = self.gate(full_x, gate_msa, attn_out)
-            distributed_x = _distribute_input_sp(full_x, self.context_group)
+            attn_out = _distribute_input_sp(attn_out, self.context_group)
         else:
             attn_out = self.self_attn(input_x_local, f, freqs, L=L)
-            gate_msa_local = get_mod_chunk(2, sp_slice=has_seq and sp_slice_args or None)
-            distributed_x = self.gate(distributed_x, gate_msa_local, attn_out)
-
+        x = self.gate(x, gate_msa, attn_out)
+        del gate_msa, attn_out
         # cross-attention
-        attn_out = self.cross_attn(self.cross_attn_norm(distributed_x), context, attn_mask=context_mask)
-        distributed_x.add_(attn_out)
+        attn_out = self.cross_attn(self.cross_attn_norm(x), context, attn_mask=context_mask)
+        x.add_(attn_out)
         del attn_out
 
-        shift = get_mod_chunk(4, sp_slice=has_seq and sp_slice_args or None)
-        scale = get_mod_chunk(3, sp_slice=has_seq and sp_slice_args or None)
-        gate  = get_mod_chunk(5, sp_slice=has_seq and sp_slice_args or None)
+        shift = get_mod_chunk(4)
+        scale = get_mod_chunk(3)
+        gate  = get_mod_chunk(5)
 
-        distributed_input_x = modulate(self.ffn_norm(distributed_x), shift, scale)
-        distributed_ffn_out = self.ffn(distributed_input_x)
-        del distributed_input_x
-        distributed_x = self.gate(distributed_x, gate, distributed_ffn_out)
+        def chunked_ffn(input_x, shift, scale, gate, chunk_size):
+            B, N, D = input_x.shape
+            out = torch.empty_like(input_x)
+
+            for start in range(0, N, chunk_size):
+                end = min(start + chunk_size, N)
+
+                x_chunk = input_x[:, start:end, :]
+                if shift.shape[1] == 1:
+                    shift_chunk = shift
+                else:
+                    shift_chunk = shift[:, start:end, :]
+                if scale.shape[1] == 1:
+                    scale_chunk = scale
+                else:
+                    scale_chunk = scale[:, start:end, :]
+                if gate.shape[1] == 1:
+                    gate_chunk = gate
+                else:
+                    gate_chunk = gate[:, start:end, :]
+
+                inp_chunk = modulate(self.ffn_norm(x_chunk), shift_chunk, scale_chunk)
+                out[:, start:end, :] = self.gate(x_chunk, gate_chunk, self.ffn(inp_chunk))
+            return out
+
+        chunk_size = 2310
+        x = chunked_ffn(x, shift, scale, gate, chunk_size)
         del shift, scale, gate
 
-        if self.is_last_block and use_seq_parallel:
-            full_x = _gather_input_sp(distributed_x, self.context_group)
-            return full_x
-
-        return distributed_x
+        return x
 
 
 class MLP(torch.nn.Module):
@@ -994,7 +995,6 @@ class KairosDiT(torch.nn.Module):
             x = [u + v for u, v in zip(x, y_camera)]
             x = x[0].unsqueeze(0)
         grid_size = x.shape[2:]
-        x = rearrange(x, 'b c f h w -> b (f h w) c').contiguous()
         return x, grid_size
 
     def unpatchify(self, x: torch.Tensor, grid_size: torch.Tensor):

--- a/kairos/pipelines/kairos_embodied_pipeline_dmd.py
+++ b/kairos/pipelines/kairos_embodied_pipeline_dmd.py
@@ -24,7 +24,8 @@ from kairos.apis.builder import KAIROS_PROCESSOR
 import torch.distributed as dist
 from kairos.modules.utils import parallel_state
 from kairos.modules.vaes.parallel_vae_wrapper import ParallelVAEWrapper
-import time
+from kairos.modules.utils.tp_utils import _gather_input_sp, _distribute_input_sp
+
 # from ..models.init_parameters import init_parameters
 from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import (
     Qwen2RMSNorm,
@@ -37,12 +38,13 @@ import torch.nn.functional as F
 @KAIROS_PROCESSOR.register_module()
 class KairosEmbodiedPipeline_DMD(BasePipeline):
 
-    def __init__(self, device="cuda", torch_dtype=torch.bfloat16, vram_management_enabled = False):
+    def __init__(self, device="cuda", torch_dtype=torch.bfloat16, vram_management_enabled = False, use_unified_sequence_parallel=False):
         super().__init__(
             device=device, torch_dtype=torch_dtype,
             height_division_factor=16, width_division_factor=16, time_division_factor=4, time_division_remainder=1,
             vram_management_enabled= vram_management_enabled
         )
+        self.use_unified_sequence_parallel = use_unified_sequence_parallel
         # self.scheduler = FlowMatchScheduler(shift=5, sigma_min=0.0, extra_one_step=True)
         self.score_scheduler = FlowMatchScheduler(shift=5, sigma_min=0.0, extra_one_step=True,
                                             exponential_shift=False, exponential_shift_mu=1.609)
@@ -103,10 +105,11 @@ class KairosEmbodiedPipeline_DMD(BasePipeline):
         selected_sampling_time=[],
         vram_management_enabled = False,
         parallel_mode = None,
+        use_unified_sequence_parallel=False
     ):
         
         # Initialize pipeline
-        pipe = KairosEmbodiedPipeline_DMD(device=device, torch_dtype=torch_dtype, vram_management_enabled=vram_management_enabled)
+        pipe = KairosEmbodiedPipeline_DMD(device=device, torch_dtype=torch_dtype, vram_management_enabled=vram_management_enabled, use_unified_sequence_parallel=use_unified_sequence_parallel)
         pipe.selected_sampling_time = selected_sampling_time
         
         # ***********************************************************
@@ -1079,29 +1082,55 @@ def model_fn_wan_video(
             drop_motion_frames=drop_motion_frames,
             use_gradient_checkpointing_offload=use_gradient_checkpointing_offload,
             use_gradient_checkpointing=use_gradient_checkpointing,
-            use_unified_sequence_parallel=use_unified_sequence_parallel,
+            use_unified_sequence_parallel=None,
         )
 
-    if use_unified_sequence_parallel:
-        from xfuser.core.distributed import (get_sequence_parallel_rank,
-                                            get_sequence_parallel_world_size,
-                                            get_sp_group)
-
     # Timestep
-    if dit.seperated_timestep and fuse_vae_embedding_in_latents:
-        timestep = torch.concat([
-            torch.zeros((1, latents.shape[3] * latents.shape[4] // 4), dtype=latents.dtype, device=latents.device),
-            torch.ones((latents.shape[2] - 1, latents.shape[3] * latents.shape[4] // 4), dtype=latents.dtype, device=latents.device) * timestep
-        ]).flatten()
-        t = dit.time_embedding(sinusoidal_embedding_1d(dit.freq_dim, timestep).unsqueeze(0))
-        if use_unified_sequence_parallel and dist.is_initialized() and dist.get_world_size() > 1:
-            t_chunks = torch.chunk(t, get_sequence_parallel_world_size(), dim=1)
-            t_chunks = [torch.nn.functional.pad(chunk, (0, 0, 0, t_chunks[0].shape[1]-chunk.shape[1]), value=0) for chunk in t_chunks]
-            t = t_chunks[get_sequence_parallel_rank()]
-        t_mod = dit.time_projection(t).unflatten(2, (6, dit.dim))
+    if use_unified_sequence_parallel:
+        cp_world_size = parallel_state.get_context_parallel_world_size()
     else:
-        t = dit.time_embedding(sinusoidal_embedding_1d(dit.freq_dim, timestep))
-        t_mod = dit.time_projection(t).unflatten(1, (6, dit.dim))
+        cp_world_size = 0
+
+    if cp_world_size > 1:
+        cp_rank = parallel_state.get_context_parallel_rank()
+        tokens_per_frame = latents.shape[3] * latents.shape[4] // 4
+        num_frames = latents.shape[2]
+        total_tokens = num_frames * tokens_per_frame
+
+        if total_tokens % cp_world_size != 0:
+            raise ValueError(
+                f"total_tokens={total_tokens} must be divisible by cp_world_size={cp_world_size}"
+            )
+
+        local_tokens = total_tokens // cp_world_size
+        start = cp_rank * local_tokens
+        end = start + local_tokens
+
+        if dit.seperated_timestep and fuse_vae_embedding_in_latents:
+            global_token_idx = torch.arange(start, end, device=latents.device)
+            frame_idx = global_token_idx // tokens_per_frame
+
+            timestep_local = torch.where(
+                frame_idx == 0,
+                torch.zeros((), dtype=latents.dtype, device=latents.device),
+                torch.as_tensor(timestep, dtype=latents.dtype, device=latents.device),
+            )
+            t = dit.time_embedding(sinusoidal_embedding_1d(dit.freq_dim, timestep_local).unsqueeze(0))
+            t_mod = dit.time_projection(t).unflatten(2, (6, dit.dim))
+        else:
+            t = dit.time_embedding(sinusoidal_embedding_1d(dit.freq_dim, timestep))
+            t_mod = dit.time_projection(t).unflatten(1, (6, dit.dim))
+    else:
+        if dit.seperated_timestep and fuse_vae_embedding_in_latents:
+            timestep = torch.concat([
+                torch.zeros((1, latents.shape[3] * latents.shape[4] // 4), dtype=latents.dtype, device=latents.device),
+                torch.ones((latents.shape[2] - 1, latents.shape[3] * latents.shape[4] // 4), dtype=latents.dtype, device=latents.device) * timestep
+            ]).flatten()
+            t = dit.time_embedding(sinusoidal_embedding_1d(dit.freq_dim, timestep).unsqueeze(0))
+            t_mod = dit.time_projection(t).unflatten(2, (6, dit.dim))
+        else:
+            t = dit.time_embedding(sinusoidal_embedding_1d(dit.freq_dim, timestep))
+            t_mod = dit.time_projection(t).unflatten(1, (6, dit.dim))
     
     # Motion Controller
     if motion_bucket_id is not None and motion_controller is not None:
@@ -1128,8 +1157,6 @@ def model_fn_wan_video(
     # Merged cfg
     if x.shape[0] != context.shape[0]:
         x = torch.concat([x] * context.shape[0], dim=0)
-    if timestep.shape[0] != context.shape[0]:
-        timestep = torch.concat([timestep] * context.shape[0], dim=0)
 
     # Image Embedding
     if y is not None and dit.require_vae_embedding:
@@ -1140,6 +1167,40 @@ def model_fn_wan_video(
 
     # Add camera control
     x, (f, h, w) = dit.patchify(x, control_camera_latents_input)
+    if use_unified_sequence_parallel and cp_world_size > 1:
+        x_full = rearrange(x, 'b c f h w -> b (f h w) c')
+        x = _distribute_input_sp(x_full, parallel_state.get_context_parallel_group())
+        del x_full
+        total_tokens = f * h * w
+        assert total_tokens % cp_world_size == 0
+
+        local_tokens = total_tokens // cp_world_size
+        start = cp_rank * local_tokens
+        end = start + local_tokens
+
+        global_token_idx = torch.arange(start, end, device=x.device)
+
+        frame_idx = global_token_idx // (h * w)
+        rem = global_token_idx % (h * w)
+        h_idx = rem // w
+        w_idx = rem % w
+
+        freq_f_table = dit.freqs[0] if dit.freqs[0].device == x.device else dit.freqs[0].to(x.device)
+        freq_h_table = dit.freqs[1] if dit.freqs[1].device == x.device else dit.freqs[1].to(x.device)
+        freq_w_table = dit.freqs[2] if dit.freqs[2].device == x.device else dit.freqs[2].to(x.device)
+
+        freqs = torch.cat([
+            freq_f_table.index_select(0, frame_idx),
+            freq_h_table.index_select(0, h_idx),
+            freq_w_table.index_select(0, w_idx),
+        ], dim=-1).unsqueeze(1)   # [local_tokens, 1, dim]
+    else:
+        x = rearrange(x, 'b c f h w -> b (f h w) c').contiguous()
+        freqs = torch.cat([
+            dit.freqs[0][:f].view(f, 1, 1, -1).expand(f, h, w, -1),
+            dit.freqs[1][:h].view(1, h, 1, -1).expand(f, h, w, -1),
+            dit.freqs[2][:w].view(1, 1, w, -1).expand(f, h, w, -1)
+        ], dim=-1).reshape(f * h * w, 1, -1).to(x.device)
     grid_size = (f, h, w)
 
     # Reference image
@@ -1149,14 +1210,7 @@ def model_fn_wan_video(
         reference_latents = dit.ref_conv(reference_latents).flatten(2).transpose(1, 2)
         x = torch.concat([reference_latents, x], dim=1)
         f += 1
-    
-    freqs = torch.cat([
-        dit.freqs[0][:f].view(f, 1, 1, -1).expand(f, h, w, -1),
-        dit.freqs[1][:h].view(1, h, 1, -1).expand(f, h, w, -1),
-        dit.freqs[2][:w].view(1, 1, w, -1).expand(f, h, w, -1)
-    ], dim=-1).reshape(f * h * w, 1, -1).to(x.device)
 
-    
     # TeaCache
     if tea_cache is not None:
         tea_cache_update = tea_cache.check(dit, x, t_mod)
@@ -1165,15 +1219,7 @@ def model_fn_wan_video(
         
     if vace_context is not None:
         vace_hints = vace(x, vace_context, context, t_mod, freqs)
-    
-    raw_shape = x.shape
-    # blocks
-    if use_unified_sequence_parallel:
-        if dist.is_initialized() and dist.get_world_size() > 1:
-            chunks = torch.chunk(x, get_sequence_parallel_world_size(), dim=1)
-            pad_shape = chunks[0].shape[1] - chunks[-1].shape[1]
-            chunks = [torch.nn.functional.pad(chunk, (0, 0, 0, chunks[0].shape[1]-chunk.shape[1]), value=0) for chunk in chunks]
-            x = chunks[get_sequence_parallel_rank()]
+
     if tea_cache_update:
         x = tea_cache.update(x)
     else:
@@ -1214,17 +1260,15 @@ def model_fn_wan_video(
     # assert raw_shape == now_shape, 'shape not same, check seq prallel, {} vs {}'.format(raw_shape, now_shape)
     # debug info 
     # *********************************
-
     x = dit.head(x, t)
-    if use_unified_sequence_parallel:
-        if dist.is_initialized() and dist.get_world_size() > 1:
-            x = get_sp_group().all_gather(x, dim=1)
-            x = x[:, :-pad_shape] if pad_shape > 0 else x
+    x_full = _gather_input_sp(x, parallel_state.get_context_parallel_group())
+    del x
     # Remove reference latents
     if reference_latents is not None:
-        x = x[:, reference_latents.shape[1]:]
+        x_full = x_full[:, reference_latents.shape[1]:]
         f -= 1
-    x = dit.unpatchify(x, (f, h, w))
+    x = dit.unpatchify(x_full, (f, h, w))
+    del x_full, t
     return x
 
 


### PR DESCRIPTION
## Summary

This PR adds two memory optimizations:

- **FFN chunking** to reduce peak memory usage on single GPU
- **SP-parallel `t_mod`** to reduce redundant memory usage across ranks in multi-GPU runs

## Details

### FFN chunking
FFN computation is split into smaller chunks along the sequence dimension, which lowers peak activation memory without changing the overall computation flow.

### SP-parallel `t_mod`
`t_mod` is sharded following the sequence-parallel layout, so each rank only keeps its local slice instead of a full copy.

## Benefits

- lower single-GPU peak memory
- lower per-rank memory usage in SP
- improved stability for long-sequence / high-resolution cases

## Test Report
https://ones.ainewera.com/wiki/#/team/Ttz6FJha/space/Qkwz271e/page/3EA8NGLm/edit