### PR TITLE
docs: improve QUICKSTART for model config selection and multi-GPU usage

### DIFF
--- a/.github/commons/examples/inference.py
+++ b/.github/commons/examples/inference.py
@@ -29,7 +29,6 @@ def parse_args():
     parser.add_argument('--input_file', default='', help='input_file')
     parser.add_argument('--config_file', default='.github/commons/examples/configs/kairos_4b_config_DMD_A800.py', help='config_file')
 
-
     args = parser.parse_args()
 
     return args

--- a/README.md
+++ b/README.md
@@ -306,12 +306,19 @@ hf download Wan-AI/Wan2.1-T2V-14B \
   --include "Wan2.1_VAE.pth"  
 
 # Step2: Run the examples
+# The example JSON files provided here are intended for the
+# `kairos-sensenova-robot-4B-480P-distilled` model.
+#
+# For TI2V and I2V, please use the 480P JSON configs. This distilled model is
+# optimized for 480P, and its performance at 720P is not ideal.
+#
+# For other models and the matching configs, please refer to `docs/QUICKSTART.md`.
 # Text2Video
-bash examples/inference.sh examples/example_t2v.json
+bash examples/inference.sh examples/example_t2v_480P.json
 # Text&FirstImage2Video
-bash examples/inference.sh examples/example_ti2v.json
+bash examples/inference.sh examples/example_ti2v_480P.json
 # FirstImage2Video
-bash examples/inference.sh examples/example_i2v.json
+bash examples/inference.sh examples/example_i2v_480P.json
 ```
 
 ## 👥 7. About Us

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -91,9 +91,17 @@ snapshot_download(
 
 # Model Inference
 
+> 💡 Platform Notes
+>
+> The setup and inference procedure are largely the same for **A800/A100**, **RTX 5090**, and **Metax C500**.
+> The following instructions describe the common workflow.
+>
+> Platform-specific differences mainly involve environment selection, such as choosing the correct Docker image for your hardware.
+
 ## Prepare inference configs 
 > 💡 If you are not using the default save paths above, update the model paths in your config.  
-> See **[`kairos/configs/kairos_4b_config.py`](kairos/configs/kairos_4b_config.py)** for examples.
+> See **[`kairos/configs/kairos_4b_config.py`](kairos/configs/kairos_4b_config.py)** and **[`kairos/configs/kairos_4b_config_DMD.py`](kairos/configs/kairos_4b_config_DMD.py)** for examples.  
+> In general, use `kairos_4b_config_DMD.py` for **`kairos-sensenova-robot-4B-480P-distilled`**, and `kairos_4b_config.py` for other Kairos models.
 
 Kairos-sensenova-4B supports `T2V`/`I2V`/`TI2V` modes, select mode by setting the value of `prompt` and `input_image`. The main differences among these modes are shown below.
 ```python
@@ -123,34 +131,48 @@ Kairos-sensenova-4B supports `T2V`/`I2V`/`TI2V` modes, select mode by setting th
     # other args ...
 }
 ```
-> 💡 Tips: For more information of generating parameters, refer to `examples/example_*.json` and `__call__` function in the `kairos/pipelines/pipelines/kairos_video_pipeline.py`.
-
+> 💡 Tips: For more information of generating parameters, refer to `examples/example_*.json` and `__call__` function in the `kairos/pipelines/pipelines/kairos_video_pipeline_DMD.py`.
 
 ## Run Generation using single-GPU without Prompt Rewriter
-> 💡 These commands require ≥80GB GPU VRAM. Recommended GPUs: NVIDIA A100 / A800 .
 
+> 💡 Model / Config Matching
+>
+> Different models should be used with the corresponding `--config` file:
+>
+> - **`kairos-sensenova-robot-4B-480P-distilled`** → use **`kairos/configs/kairos_4b_config_DMD.py`**
+> - **other Kairos models** → use **`kairos/configs/kairos_4b_config.py`**
+>
+> In addition, the example JSON should match the selected model and target resolution for the best results.
+>
+> - For **`kairos-sensenova-robot-4B-480P-distilled`**, please use the **480P JSON configs** such as:
+>   - `examples/example_t2v_480P.json`
+>   - `examples/example_ti2v_480P.json`
+>   - `examples/example_i2v_480P.json`
+>
+> This distilled model is optimized for **480P**, and its performance at **720P** is not ideal.
+>
 - example of t2v inference
 ```bash
-bash examples/inference.sh examples/example_t2v.json
+bash examples/inference.sh examples/_example_t2v_480P.json kairos/configs/kairos_4b_config_DMD.py
 ```
 
 - example of ti2v inference
 ```bash
-bash examples/inference.sh examples/example_ti2v.json
+bash examples/inference.sh examples/example_ti2v_480P.json kairos/configs/kairos_4b_config_DMD.py
 ```
 
 - example of i2v inference
 ```bash
-bash examples/inference.sh examples/example_i2v.json
+bash examples/inference.sh examples/example_i2v_480P.json kairos/configs/kairos_4b_config_DMD.py
 ```
 
-> 💡 Tips: The default video resolution is 704x1280. You can modify the resolution in the example.json. For example, if you want to generate a 480P video, use `examples/example_i2v_480P.json`, `examples/example_t2v_480P.json` and `examples/example_ti2v_480P.json`.
+> 💡 Tips: The default video resolution is 480x640. You can modify the resolution in the example.json. For example, if you want to generate a 720P video, use `examples/example_i2v.json`, `examples/example_t2v.json` and `examples/example_ti2v.json`.
 
 ## Run Generation using Multi-GPU (torchrun)
 > ⚠️ Multi-GPU supports two modes:
 > - **Pure-TP** (no CFG-parallel): `tp_size = WORLD_SIZE`, requires `num_heads % WORLD_SIZE == 0`.
 > - **CFG-parallel**: splits positive/negative branches across GPUs, currently supported **only for WORLD_SIZE = 4 or 8**.
-
+> - **`kairos-sensenova-robot-4B-480P-distilled` does not support CFG-parallel**. Please use it without CFG-parallel enabled.
 > ⚙️ Additional Config for Multi-GPU Inference
 
 > When running with multi_gpu_inference.sh, you must enable tensor / sequence parallel related flags in the model config.
@@ -191,20 +213,21 @@ pipeline = dict(
     use_cfg_parallel=True
 )
 ```
->💡 Notes: `use_cfg_parallel` here enables **CFG-parallel** (distributed cond/uncond execution).  
+>💡 Notes: `use_cfg_parallel` here enables **CFG-parallel** (distributed cond/uncond execution).
+>💡 Example commands below use **4 GPUs** with `kairos/configs/kairos_4b_config_DMD.py`, and are intended for **`kairos-sensenova-robot-4B-480P-distilled`** with the corresponding **480P** example JSONs.
 - example of t2v inference
 ```bash
-bash examples/multi_gpu_inference.sh examples/example_t2v.json
+bash examples/multi_gpu_inference.sh examples/example_t2v_480P.json kairos/configs/kairos_4b_config_DMD.py 4
 ```
 
 - example of ti2v inference
 ```bash
-bash examples/multi_gpu_inference.sh examples/example_ti2v.json
+bash examples/multi_gpu_inference.sh examples/example_ti2v_480P.json kairos/configs/kairos_4b_config_DMD.py 4
 ```
 
 - example of i2v inference
 ```bash
-bash examples/multi_gpu_inference.sh examples/example_i2v.json
+bash examples/multi_gpu_inference.sh examples/example_i2v_480P.json kairos/configs/kairos_4b_config_DMD.py 4
 ```
 ## Enable TeaCache
 > ⚙️ TeaCache (Optional, works on both single-GPU and multi-GPU)

--- a/examples/inference.py
+++ b/examples/inference.py
@@ -17,6 +17,11 @@ from kairos.modules.utils import save_video, save_image, parallel_state, FLAGS_K
 def parse_args():
     parser = argparse.ArgumentParser(description='TRAIN_MODEL_LOOP')
     parser.add_argument('--input_file', default='', help='input_file')
+    parser.add_argument(
+        '--config_file',
+        default='kairos/configs/kairos_4b_config_DMD.py',
+        help='path to config file'
+    )
 
     args = parser.parse_args()
 
@@ -75,7 +80,7 @@ if __name__ == '__main__':
 
     args = parse_args()
 
-    cfg_path = "kairos/configs/kairos_4b_config_DMD.py"
+    cfg_path = args.config_file
 
     if cfg_path == '':
         ValueError('config path is empty')

--- a/examples/inference.sh
+++ b/examples/inference.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-INPUT_FILE=${1:-"examples/example_t2v.json"}
+INPUT_FILE=${1:-"examples/example_t2v_480P.json"}
+CONFIG_FILE=${2:-"kairos/configs/kairos_4b_config_DMD.py"}
 
 CURR_FILE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CODE_DIR="$(cd "${CURR_FILE_DIR}/.." && pwd)"
 
-
-cd $CODE_DIR
+cd $CODE_DIR || exit 1
 
 export PYTHONPATH=${CODE_DIR}:$PYTHONPATH
 python ${CODE_DIR}/kairos/third_party/manage_libs.py
@@ -14,5 +14,4 @@ python ${CODE_DIR}/kairos/third_party/manage_libs.py
 torchrun --nnodes=1  --master_port 29556 --nproc-per-node=1 \
     ${CODE_DIR}/examples/inference.py \
         --input_file ${INPUT_FILE} \
-
-
+        --config_file "$CONFIG_FILE"

--- a/examples/multi_gpu_inference.sh
+++ b/examples/multi_gpu_inference.sh
@@ -1,26 +1,30 @@
 #!/bin/bash
 
-INPUT_FILE=${1:-"examples/example_t2v.json"}
+INPUT_FILE=${1:-"examples/example_t2v_480P.json"}
+CONFIG_FILE=${2:-"kairos/configs/kairos_4b_config_DMD.py"}
+GPU=${3:-4}
 
 CURR_FILE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CODE_DIR="$(cd "${CURR_FILE_DIR}/.." && pwd)"
 
+cd "$CODE_DIR" || exit 1
 
-cd $CODE_DIR
-
-export PYTHONPATH=${CODE_DIR}:$PYTHONPATH
-python ${CODE_DIR}/kairos/third_party/manage_libs.py
+export PYTHONPATH="${CODE_DIR}:$PYTHONPATH"
+python "${CODE_DIR}/kairos/third_party/manage_libs.py"
 
 # NOTE:
-# - This script supports **2-GPU** and **4-GPU** parallel inference only (nproc-per-node=2 or 4).
-# - When **CFG-parallel** is enabled (cond/uncond split), it runs as **two** parallel groups:
-#     - 2 groups × 2 GPUs (requires **4 GPUs** total), or
-#     - 2 groups × 4 GPUs (requires **8 GPUs** total).
+# - This script supports 2-GPU, 4-GPU, and 8-GPU parallel inference only.
 # - Other configurations (e.g., 6 GPUs, multi-node) are not supported yet.
+# - When CFG-parallel is enabled (cond/uncond split), it runs as two parallel groups:
+#     - 2 groups × 2 GPUs (requires 4 GPUs total), or
+#     - 2 groups × 4 GPUs (requires 8 GPUs total).
 
-GPU=4
-torchrun --nnodes=1  --master_port 29556 --nproc-per-node=$GPU \
-    ${CODE_DIR}/examples/inference.py \
-        --input_file ${INPUT_FILE} \
+if [[ "$GPU" != "2" && "$GPU" != "4" && "$GPU" != "8" ]]; then
+    echo "Error: GPU must be 2, 4, or 8"
+    exit 1
+fi
 
-
+torchrun --nnodes=1 --master_port 29556 --nproc-per-node="$GPU" \
+    "${CODE_DIR}/examples/inference.py" \
+    --input_file "$INPUT_FILE" \
+    --config_file "$CONFIG_FILE"

--- a/kairos/configs/kairos_4b_config.py
+++ b/kairos/configs/kairos_4b_config.py
@@ -2,7 +2,7 @@
 
 KAIROS_MODEL_DIR = 'models'
 
-pretrained_dit = f'{KAIROS_MODEL_DIR}/Kairos/models/robot/kairos-robot-4B-480P-16fps.safetensors'
+pretrained_dit = f'{KAIROS_MODEL_DIR}/Kairos/models/robot/kairos-common-4B-720P.safetensors'
 text_encoder_path =  f'{KAIROS_MODEL_DIR}/Qwen/Qwen2.5-VL-7B-Instruct-AWQ/'
 vae_path = f'{KAIROS_MODEL_DIR}/Wan2.1-T2V-14B/Wan2.1_VAE.pth'
 prompt_rewriter_path = f'{KAIROS_MODEL_DIR}/Qwen/Qwen3-VL-8B-Instruct/'

--- a/kairos/pipelines/kairos_embodied_pipeline.py
+++ b/kairos/pipelines/kairos_embodied_pipeline.py
@@ -21,6 +21,7 @@ from kairos.apis.builder import KAIROS_PROCESSOR
 import torch.distributed as dist
 from kairos.modules.utils import parallel_state
 from kairos.modules.vaes.parallel_vae_wrapper import ParallelVAEWrapper
+from kairos.modules.utils.tp_utils import _gather_input_sp, _distribute_input_sp
 
 @KAIROS_PROCESSOR.register_module()
 class KairosEmbodiedPipeline(BasePipeline):
@@ -1077,19 +1078,53 @@ def model_fn_wan_video(
             batch_size=2 if cfg_merge else 1
         )
 
-
     # Timestep
-    if dit.seperated_timestep and fuse_vae_embedding_in_latents:
-        timestep = torch.concat([
-            torch.zeros((1, latents.shape[3] * latents.shape[4] // 4), dtype=latents.dtype, device=latents.device),
-            torch.ones((latents.shape[2] - 1, latents.shape[3] * latents.shape[4] // 4), dtype=latents.dtype, device=latents.device) * timestep
-        ]).flatten()
-        t = dit.time_embedding(sinusoidal_embedding_1d(dit.freq_dim, timestep).unsqueeze(0))
-        t_mod = dit.time_projection(t).unflatten(2, (6, dit.dim))
+    if use_unified_sequence_parallel:
+        cp_world_size = parallel_state.get_context_parallel_world_size()
     else:
-        t = dit.time_embedding(sinusoidal_embedding_1d(dit.freq_dim, timestep))
-        t_mod = dit.time_projection(t).unflatten(1, (6, dit.dim))
+        cp_world_size = 0
 
+    if cp_world_size > 1:
+        cp_rank = parallel_state.get_context_parallel_rank()
+        tokens_per_frame = latents.shape[3] * latents.shape[4] // 4
+        num_frames = latents.shape[2]
+        total_tokens = num_frames * tokens_per_frame
+
+        if total_tokens % cp_world_size != 0:
+            raise ValueError(
+                f"total_tokens={total_tokens} must be divisible by cp_world_size={cp_world_size}"
+            )
+
+        local_tokens = total_tokens // cp_world_size
+        start = cp_rank * local_tokens
+        end = start + local_tokens
+
+        if dit.seperated_timestep and fuse_vae_embedding_in_latents:
+            global_token_idx = torch.arange(start, end, device=latents.device)
+            frame_idx = global_token_idx // tokens_per_frame
+
+            timestep_local = torch.where(
+                frame_idx == 0,
+                torch.zeros((), dtype=latents.dtype, device=latents.device),
+                torch.as_tensor(timestep, dtype=latents.dtype, device=latents.device),
+            )
+            t = dit.time_embedding(sinusoidal_embedding_1d(dit.freq_dim, timestep_local).unsqueeze(0))
+            t_mod = dit.time_projection(t).unflatten(2, (6, dit.dim))
+        else:
+            t = dit.time_embedding(sinusoidal_embedding_1d(dit.freq_dim, timestep))
+            t_mod = dit.time_projection(t).unflatten(1, (6, dit.dim))
+    else:
+        if dit.seperated_timestep and fuse_vae_embedding_in_latents:
+            timestep = torch.concat([
+                torch.zeros((1, latents.shape[3] * latents.shape[4] // 4), dtype=latents.dtype, device=latents.device),
+                torch.ones((latents.shape[2] - 1, latents.shape[3] * latents.shape[4] // 4), dtype=latents.dtype, device=latents.device) * timestep
+            ]).flatten()
+            t = dit.time_embedding(sinusoidal_embedding_1d(dit.freq_dim, timestep).unsqueeze(0))
+            t_mod = dit.time_projection(t).unflatten(2, (6, dit.dim))
+        else:
+            t = dit.time_embedding(sinusoidal_embedding_1d(dit.freq_dim, timestep))
+            t_mod = dit.time_projection(t).unflatten(1, (6, dit.dim))
+    
     # Motion Controller
     if motion_bucket_id is not None and motion_controller is not None:
         t_mod = t_mod + motion_controller(motion_bucket_id).unflatten(1, (6, dit.dim))
@@ -1115,8 +1150,6 @@ def model_fn_wan_video(
     # Merged cfg
     if x.shape[0] != context.shape[0]:
         x = torch.concat([x] * context.shape[0], dim=0)
-    if timestep.shape[0] != context.shape[0]:
-        timestep = torch.concat([timestep] * context.shape[0], dim=0)
 
     # Image Embedding
     if y is not None and dit.require_vae_embedding:
@@ -1127,6 +1160,40 @@ def model_fn_wan_video(
 
     # Add camera control
     x, (f, h, w) = dit.patchify(x, control_camera_latents_input)
+    if use_unified_sequence_parallel and cp_world_size > 1:
+        x_full = rearrange(x, 'b c f h w -> b (f h w) c')
+        x = _distribute_input_sp(x_full, parallel_state.get_context_parallel_group())
+        del x_full
+        total_tokens = f * h * w
+        assert total_tokens % cp_world_size == 0
+
+        local_tokens = total_tokens // cp_world_size
+        start = cp_rank * local_tokens
+        end = start + local_tokens
+
+        global_token_idx = torch.arange(start, end, device=x.device)
+
+        frame_idx = global_token_idx // (h * w)
+        rem = global_token_idx % (h * w)
+        h_idx = rem // w
+        w_idx = rem % w
+
+        freq_f_table = dit.freqs[0] if dit.freqs[0].device == x.device else dit.freqs[0].to(x.device)
+        freq_h_table = dit.freqs[1] if dit.freqs[1].device == x.device else dit.freqs[1].to(x.device)
+        freq_w_table = dit.freqs[2] if dit.freqs[2].device == x.device else dit.freqs[2].to(x.device)
+
+        freqs = torch.cat([
+            freq_f_table.index_select(0, frame_idx),
+            freq_h_table.index_select(0, h_idx),
+            freq_w_table.index_select(0, w_idx),
+        ], dim=-1).unsqueeze(1)   # [local_tokens, 1, dim]
+    else:
+        x = rearrange(x, 'b c f h w -> b (f h w) c').contiguous()
+        freqs = torch.cat([
+            dit.freqs[0][:f].view(f, 1, 1, -1).expand(f, h, w, -1),
+            dit.freqs[1][:h].view(1, h, 1, -1).expand(f, h, w, -1),
+            dit.freqs[2][:w].view(1, 1, w, -1).expand(f, h, w, -1)
+        ], dim=-1).reshape(f * h * w, 1, -1).to(x.device)
     grid_size = (f, h, w)
 
     # Reference image
@@ -1136,12 +1203,6 @@ def model_fn_wan_video(
         reference_latents = dit.ref_conv(reference_latents).flatten(2).transpose(1, 2)
         x = torch.concat([reference_latents, x], dim=1)
         f += 1
-
-    freqs = torch.cat([
-        dit.freqs[0][:f].view(f, 1, 1, -1).expand(f, h, w, -1),
-        dit.freqs[1][:h].view(1, h, 1, -1).expand(f, h, w, -1),
-        dit.freqs[2][:w].view(1, 1, w, -1).expand(f, h, w, -1)
-    ], dim=-1).reshape(f * h * w, 1, -1).to(x.device)
 
     # TeaCache
     if tea_cache is not None:
@@ -1185,7 +1246,6 @@ def model_fn_wan_video(
             tea_cache.store(x)
 
     x = dit.head(x, t)
-
     # Remove reference latents
     if reference_latents is not None:
         x = x[:, reference_latents.shape[1]:]


### PR DESCRIPTION
## Summary

This PR improves the QUICKSTART / README documentation and related inference scripts to make model selection and inference usage clearer across different platforms.

## What’s changed

### Documentation
- Clarified that the workflow is generally the same across **A800**, **RTX 5090**, and **Metax**, and that the following instructions describe the common steps.
- Added **model / config / JSON matching** guidance:
  - `kairos-sensenova-robot-4B-480P-distilled` → `kairos/configs/kairos_4b_config_DMD.py`
  - other Kairos models → `kairos/configs/kairos_4b_config.py`
- Added notes that the distilled robot model is optimized for **480P**, and that **TI2V / I2V** should use the corresponding **480P JSON** configs for best results.
- Clarified that the distilled model does **not** perform well at **720P**.
- Added examples showing how to select different configs in inference commands.
- Clarified multi-GPU usage and limitations, including:
  - support for **2 / 4 / 8 GPUs**
  - **CFG-parallel** is only supported for `WORLD_SIZE=4` or `8`
  - **distilled models do not support CFG-parallel**

### Scripts
- Updated the inference script usage so that `--config` can be passed from the shell script.
- Updated the multi-GPU inference script to support configurable GPU count (`2 / 4 / 8`) instead of a fixed value.

## Why

Previously, the docs did not clearly explain:
- which config file should be used for different models
- how JSON examples should match model resolution
- how platform differences should be interpreted
- how to pass config files in inference scripts
- the limitation that distilled models do not support CFG-parallel

This PR makes the setup and inference flow easier to follow and reduces confusion when switching between standard models and the `robot-4B-480P-distilled` model.